### PR TITLE
Added basic Laminas support

### DIFF
--- a/src/Listener/RouteListener.php
+++ b/src/Listener/RouteListener.php
@@ -23,7 +23,8 @@ namespace ZF2LanguageRoute\Listener;
 use Zend\EventManager\AbstractListenerAggregate;
 use Zend\EventManager\EventManagerInterface;
 use ZF2LanguageRoute\Options\LanguageRouteOptions;
-use Zend\Mvc\MvcEvent;
+use Zend\Mvc\MvcEvent as ZFMvcEvent;
+use Laminas\Mvc\MvcEvent as LaminasMvcEvent;
 use Zend\Router\RouteStackInterface;
 use Zend\Stdlib\RequestInterface;
 use ZF2LanguageRoute\Mvc\Router\Http\LanguageTreeRouteStack;
@@ -66,11 +67,17 @@ class RouteListener extends AbstractListenerAggregate{
 		$this->userMapper = $userMapper;
 	}
 
-	
+
 	public function attach(EventManagerInterface $events, $priority = 10) {
-		$this->listeners[] = $events->attach(MvcEvent::EVENT_ROUTE, [$this, 'onRoute'], $priority);
+        if (class_exists(ZFMvcEvent::class)) {
+            $this->listeners[] = $events->attach(ZFMvcEvent::EVENT_ROUTE, [$this, 'onRoute'], $priority);
+        }
+
+        if (class_exists(LaminasMvcEvent::class)) {
+            $this->listeners[] = $events->attach(LaminasMvcEvent::EVENT_ROUTE, [$this, 'onRoute'], $priority);
+        }
 	}
-	
+
 	public function onRoute($e){
 		$router = $this->router;
 		if(!$router instanceof LanguageTreeRouteStack){

--- a/src/Module.php
+++ b/src/Module.php
@@ -7,7 +7,8 @@ use Zend\ModuleManager\Feature\ServiceProviderInterface;
 use Zend\ModuleManager\Feature\BootstrapListenerInterface;
 use Zend\EventManager\EventInterface;
 use Zend\Mvc\MvcEvent;
-use Zend\Router\Http\TreeRouteStack;
+use Zend\Router\Http\TreeRouteStack as ZFTreeRouteStack;
+use Laminas\Router\Http\TreeRouteStack as LaminasTreeRouteStack;
 
 class Module implements ConfigProviderInterface, ServiceProviderInterface, BootstrapListenerInterface, ViewHelperProviderInterface{
 	
@@ -37,7 +38,8 @@ class Module implements ConfigProviderInterface, ServiceProviderInterface, Boots
 			],
 			'delegators' => [
 				'HttpRouter' => [ Mvc\Router\Http\Factory\LanguageTreeRouteStackDelegatorFactory::class ],
-				TreeRouteStack::class => [ Mvc\Router\Http\Factory\LanguageTreeRouteStackDelegatorFactory::class ],
+				ZFTreeRouteStack::class => [ Mvc\Router\Http\Factory\LanguageTreeRouteStackDelegatorFactory::class ],
+				LaminasTreeRouteStack::class => [ Mvc\Router\Http\Factory\LanguageTreeRouteStackDelegatorFactory::class ],
 			]
 		];
 	}


### PR DESCRIPTION
Seems I'm the only one using this library. I've added basic support for Laminas, the important part was to match the delegator against the new FQCN of the TreeRouteStack. I've tested this patch again an Laminas MVC application on PHP 7.4.